### PR TITLE
feat: use contrasting logo for better visibility

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+cockpit-branding-halos (0.2.0-1) unstable; urgency=medium
+
+  * Use contrasting logo for better visibility in all color schemes.
+
+ -- Matti Airas <matti.airas@hatlabs.fi>  Sat, 22 Nov 2025 18:00:00 +0200
+
 cockpit-branding-halos (0.1.0-1) unstable; urgency=medium
 
   * Initial release.

--- a/etc/cockpit/branding/logo.svg
+++ b/etc/cockpit/branding/logo.svg
@@ -1,9 +1,15 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
-<svg width="100%" height="100%" viewBox="0 0 1015 1015" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" xml:space="preserve" xmlns:serif="http://www.serif.com/" style="fill-rule:evenodd;clip-rule:evenodd;stroke-linejoin:round;stroke-miterlimit:1.5;">
-    <g transform="matrix(1,0,0,1,-3053.69,-2074.35)">
-        <g transform="matrix(3.76031,0,0,3.77707,401.509,1790.58)">
+<svg width="100%" height="100%" viewBox="0 0 1062 1062" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" xml:space="preserve" xmlns:serif="http://www.serif.com/" style="fill-rule:evenodd;clip-rule:evenodd;stroke-linejoin:round;stroke-miterlimit:1.5;">
+    <g transform="matrix(1,0,0,1,-192.889,-5872.89)">
+        <g transform="matrix(3.76031,0,0,3.77707,-2435.85,5612.96)">
             <g id="Pictogram">
+                <g transform="matrix(0.611351,0,0,0.60864,617.276,-1126.36)">
+                    <circle cx="207.035" cy="2059.97" r="13.094" style="fill:white;stroke:white;stroke-width:20.54px;"/>
+                </g>
+                <g transform="matrix(0.739526,0,0,0.736246,438.587,-380.399)">
+                    <path d="M545.365,618.65L543.01,618.635C506.159,618.635 470.267,629.801 440.01,650.525C437.569,652.214 435.933,654.834 435.486,657.768C435.039,660.702 435.821,663.69 437.648,666.029C437.637,666.049 437.643,666.055 437.648,666.062C441.185,670.589 447.644,671.561 452.357,668.276C458.525,663.936 465.152,659.856 472.627,656.494C488.357,649.417 507.773,640.701 543.01,640.257L545.086,640.27C632.802,641.381 703.674,712.939 703.674,800.92C703.674,888.901 632.802,960.459 545.086,961.57L543.01,961.583C454.338,961.583 382.347,889.592 382.347,800.92C382.347,776.083 388.105,751.632 399.11,729.468C401.641,724.407 399.792,718.251 394.891,715.421C394.899,715.408 394.899,715.408 394.899,715.407C392.309,713.912 389.213,713.562 386.354,714.442C383.496,715.321 381.132,717.351 379.831,720.044C377.88,723.949 375.832,728.187 374.564,731.252C365.457,753.271 360.725,776.937 360.725,800.92C360.725,901.526 442.405,983.205 543.01,983.205L545.365,983.19C644.885,981.929 725.295,900.741 725.295,800.92C725.295,701.099 644.885,619.91 545.365,618.65Z" style="fill:white;stroke:white;stroke-width:16.98px;stroke-miterlimit:2;"/>
+                </g>
                 <g transform="matrix(0.248863,0,0,0.247759,-45.9779,-429.782)">
                     <g id="Ring">
                         <circle cx="3561.1" cy="2580.14" r="506.907" style="fill:white;"/>


### PR DESCRIPTION
## Summary

- Replace `logo.svg` with contrasting version (white fills) for better visibility in all color schemes
- Bump version to 0.2.0-1

## Test plan

- [x] Package builds successfully
- [x] Package installs on test system (halos.local)
- [x] Verified new logo.svg is installed at `/usr/share/cockpit/branding/debian/logo.svg`
- [ ] Manual test: verify logo is visible in both light and dark modes

Closes hatlabs/halos-distro#27

🤖 Generated with [Claude Code](https://claude.com/claude-code)