### PR TITLE
fix(ci): update package-name to halos-cockpit-branding

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -13,7 +13,7 @@ jobs:
   build-release:
     uses: hatlabs/shared-workflows/.github/workflows/build-release.yml@main
     with:
-      package-name: cockpit-branding-halos
+      package-name: halos-cockpit-branding
       package-description: 'Custom HaLOS branding for Cockpit web interface'
       apt-distro: trixie
       apt-component: main


### PR DESCRIPTION
## Summary
- Update the workflow to use the new package name after rename
- Fixes the failed build run

## Test plan
- [ ] CI build passes with new package name

🤖 Generated with [Claude Code](https://claude.com/claude-code)