### PR TITLE
feat(layout): reduce Cockpit card height to 1

### DIFF
--- a/etc/halos/webapps.d/cockpit.toml
+++ b/etc/halos/webapps.d/cockpit.toml
@@ -16,6 +16,6 @@ visible = true
 [layout]
 priority = 10  # Core system app - placed first on dashboard
 width = 2
-height = 2
+height = 1
 x_offset = 0
 y_offset = 0


### PR DESCRIPTION
## Summary

- Reduce Cockpit dashboard card height from 2 to 1 for better visual balance

## Test plan

- [x] Tested on halos.local

🤖 Generated with [Claude Code](https://claude.com/claude-code)