### PR TITLE
fix(build): add lintian override for initial-upload-closes-no-bugs

### DIFF
--- a/debian/halos-cockpit-config.lintian-overrides
+++ b/debian/halos-cockpit-config.lintian-overrides
@@ -4,3 +4,6 @@ halos-cockpit-config: systemd-service-file-refers-to-unusual-wantedby-target coc
 
 # xdg-open is provided by xdg-utils which is a dependency
 halos-cockpit-config: desktop-command-not-in-package xdg-open [usr/share/applications/cockpit.desktop]
+
+# CI generates debian/changelog dynamically, so there is no ITP bug to close
+halos-cockpit-config: initial-upload-closes-no-bugs


### PR DESCRIPTION
## Summary

- Add lintian override for `initial-upload-closes-no-bugs` warning

CI generates `debian/changelog` dynamically at build time, so there is never an ITP bug closure entry. This warning is expected and should be suppressed.

## Test plan

- [ ] Verify CI checks pass
- [ ] Verify lintian no longer reports `initial-upload-closes-no-bugs`

🤖 Generated with [Claude Code](https://claude.com/claude-code)