### PR TITLE
Add bumpversion and lefthook commands to ./run

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,0 +1,6 @@
+[bumpversion]
+current_version = 0.5.2
+commit = True
+tag = False
+
+[bumpversion:file:VERSION]

--- a/run
+++ b/run
@@ -83,6 +83,65 @@ function clean {
 }
 
 ################################################################################
+# Setup Commands
+
+function hooks-install {
+  #@ Install pre-commit hooks using lefthook
+  #@ Category: Setup
+  if ! command -v lefthook &> /dev/null; then
+    echo "Error: lefthook not found. Install with: brew install lefthook"
+    exit 1
+  fi
+  lefthook install
+  echo "Pre-commit hooks installed"
+}
+
+function hooks-run {
+  #@ Run pre-commit hooks manually
+  #@ Category: Setup
+  if ! command -v lefthook &> /dev/null; then
+    echo "Error: lefthook not found. Install with: brew install lefthook"
+    exit 1
+  fi
+  lefthook run pre-commit
+}
+
+################################################################################
+# Version Management Commands
+
+function bumpversion {
+  #@ Bump version using bumpversion tool (patch|minor|major)
+  #@ Category: Version
+  local BUMP_TYPE="${1:-}"
+
+  if [[ -z "$BUMP_TYPE" ]]; then
+    echo "Error: version bump type required"
+    echo "Usage: ./run bumpversion [patch|minor|major]"
+    exit 1
+  fi
+
+  if [[ ! "$BUMP_TYPE" =~ ^(patch|minor|major)$ ]]; then
+    echo "Error: invalid bump type '$BUMP_TYPE'"
+    echo "Usage: ./run bumpversion [patch|minor|major]"
+    exit 1
+  fi
+
+  echo "Bumping $BUMP_TYPE version..."
+
+  if ! command -v bumpversion &> /dev/null; then
+    echo "Error: bumpversion not installed"
+    echo "Install with: pip install bump2version"
+    exit 1
+  fi
+
+  command bumpversion "$BUMP_TYPE"
+
+  echo "Version bumped and committed successfully"
+  echo "New version: $(cat VERSION)"
+  echo "Push with: git push"
+}
+
+################################################################################
 # Help System
 
 function help {


### PR DESCRIPTION
## Summary

- Adds `.bumpversion.cfg` for automated version bumps (same pattern as halos-homarr-branding)
- Adds `./run bumpversion [patch|minor|major]` command
- Adds `./run hooks-install` and `./run hooks-run` commands for lefthook management

Closes #19

## Test plan

- [x] `./run help` shows all three new commands
- [x] `./run bumpversion patch` bumps VERSION from 0.5.2 to 0.5.3 and auto-commits
- [x] `.bumpversion.cfg` updates with new version

🤖 Generated with [Claude Code](https://claude.com/claude-code)