### PR TITLE
Fix .bumpversion.cfg version out of sync

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.5.2
+current_version = 0.5.3
 commit = True
 tag = False
 


### PR DESCRIPTION
## Summary

- `.bumpversion.cfg` had `current_version = 0.5.2` while `VERSION` was already at `0.5.3`, caused by a manual version bump in PR #23 that didn't use `./run bumpversion`
- Updates `current_version` to `0.5.3` so bumpversion works correctly going forward

🤖 Generated with [Claude Code](https://claude.com/claude-code)