### PR TITLE
Fix .deb glob pattern to match renamed package

### DIFF
--- a/run
+++ b/run
@@ -41,7 +41,7 @@ function build-deb {
 
   # List generated packages
   echo "📦 Generated packages:"
-  ls -lh cockpit-branding-halos*.deb 2>/dev/null || echo "⚠️  No .deb files found"
+  ls -lh halos-cockpit-config*.deb 2>/dev/null || echo "⚠️  No .deb files found"
   echo "✅ Package build complete"
 }
 


### PR DESCRIPTION
## Summary

- `build-deb` used the old `cockpit-branding-halos*.deb` glob to list generated packages, but the package is now named `halos-cockpit-config` — so the listing always fell through to the "No .deb files found" warning
- Updates the glob to `halos-cockpit-config*.deb`

Fixes #25

🤖 Generated with [Claude Code](https://claude.com/claude-code)