### PR TITLE
docs(agents): point version-bump guidance at canonical policy

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -51,7 +51,7 @@ HaLOS-specific configuration for the Cockpit web interface. This package integra
 
 **`debian/changelog`** is generated dynamically by CI at build time (see [shared-workflows `build-release.yml`](https://github.com/halos-org/shared-workflows/blob/main/.github/workflows/build-release.yml)). The checked-in version is only used for local dev builds and will typically be out of sync with VERSION. This is expected — never manually edit `debian/changelog`.
 
-**CI enforcement**: VERSION bumps are *per release cycle*, not per PR. Default: do NOT bump `VERSION` in feature PRs — CI auto-increments the `+N` revision in release tags (e.g., `v0.5.6+1`, `+2`, `+3`) between stable releases. Bump `VERSION` only when starting a new release cycle, i.e., when `VERSION` currently matches the latest stable tag and this PR is opening the next cycle. If `VERSION` already differs from the latest stable tag, no further bump is needed regardless of how many package-affecting files this PR touches. Docs, tests, CI config, and dev tooling are automatically excluded from the check.
+**CI enforcement**: VERSION bumps are per release cycle, not per PR — CI fails only on the PR that opens a new cycle (when VERSION still matches the latest stable release and the PR touches package-affecting files); later PRs in the same cycle must not bump. See the workspace `AGENTS.md` version-bump policy for the full decision procedure.
 
 ## Project Structure
 


### PR DESCRIPTION
On `main` this file already stated the per-cycle policy, but with the old circular "this PR is opening the next cycle" phrasing that the workspace clarification removed. This replaces it with a one-line summary plus a pointer to the canonical decision procedure in the workspace `AGENTS.md` (halos-org/halos), so the guidance can't drift. Repo-specific changelog facts are kept. Docs only.

Closes #34.