### PR TITLE
chore(debian): drop stale mdns lintian override

### DIFF
--- a/debian/halos-cockpit-config.lintian-overrides
+++ b/debian/halos-cockpit-config.lintian-overrides
@@ -1,7 +1,3 @@
-# The mDNS service is intentionally wanted by cockpit.socket
-# to ensure it starts when Cockpit is activated
-halos-cockpit-config: systemd-service-file-refers-to-unusual-wantedby-target cockpit.socket [usr/lib/systemd/system/halos-cockpit-mdns.service]
-
 # xdg-open is provided by xdg-utils which is a dependency
 halos-cockpit-config: desktop-command-not-in-package xdg-open [usr/share/applications/cockpit.desktop]
 


### PR DESCRIPTION
## What

Removes the stale `systemd-service-file-refers-to-unusual-wantedby-target cockpit.socket` lintian override. `halos-cockpit-mdns.service` was removed with the mDNS service, so the override is now unused and lintian flags it as `unused-override`.

## Context — the release was unblocked elsewhere

This branch originally also added a `debian-changelog-line-too-long` override to fix the failing release build. That root cause is now fixed upstream in **halos-org/shared-workflows#27** (merged 2026-06-04), which wraps CI-generated changelog lines at 80 columns. With that in place no per-repo override is needed, so it's been dropped from this PR — adding one would just create new `unused-override` noise.

Verified locally: reproducing #27's wrapping over the real commit range, building the deb in the `debtools` container, and running `lintian --fail-on error,warning` with **no** changelog override → exit 0, clean (the long `fix(agents): …` subject folds across two lines, none over 80).

What remains here is the mdns cleanup, which stands on its own.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
